### PR TITLE
whitelist cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ runs {
 
     server {
         systemProperty 'forge.enabledGameTestNamespaces', project.mod_id
-        programArgument '--nogui'
     }
 
     // This run config launches GameTestServer and runs all registered gametests, then exits.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/ldtteam/patreonwhitelist/Commonconfig.java
+++ b/src/main/java/com/ldtteam/patreonwhitelist/Commonconfig.java
@@ -23,7 +23,7 @@ public class Commonconfig
 
     public Commonconfig(ModConfigSpec.Builder builder)
     {
-        offlineAuthValidHours = builder.define("Amount of days authentication stays valid for after last successfull auth", 24 * 7);
+        offlineAuthValidHours = builder.define("Amount of hours authentication stays valid for after last successfull auth", 24 * 7);
         loginTimes = builder.defineList("List of player UUID to last auth time", new ArrayList<>(), () -> "", v -> true);
         builder.build();
     }

--- a/src/main/java/com/ldtteam/patreonwhitelist/Commonconfig.java
+++ b/src/main/java/com/ldtteam/patreonwhitelist/Commonconfig.java
@@ -1,0 +1,117 @@
+package com.ldtteam.patreonwhitelist;
+
+import com.mojang.authlib.GameProfile;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.event.config.ModConfigEvent;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+public class Commonconfig
+{
+    private ModConfigSpec.ConfigValue<List<? extends String>> loginTimes;
+    private ModConfigSpec.ConfigValue<Integer>                offlineAuthValidHours;
+
+    private Map<UUID, NameTime> lastLoginTimes = new HashMap<>();
+    private DateTimeFormatter   timeFormatter  = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+    public  ModConfigSpec       holder         = null;
+
+    public Commonconfig(ModConfigSpec.Builder builder)
+    {
+        offlineAuthValidHours = builder.define("Amount of days authentication stays valid for after last successfull auth", 24 * 7);
+        loginTimes = builder.defineList("List of player UUID to last auth time", new ArrayList<>(), () -> "", v -> true);
+        builder.build();
+    }
+
+    /**
+     * Reloads the uuid to time map from config string values
+     */
+    private void reload()
+    {
+        Map<UUID, NameTime> temp = new HashMap<>();
+        for (final String entry : loginTimes.get())
+        {
+            if (entry == null)
+            {
+                continue;
+            }
+
+            String[] data = entry.split(";");
+            if (data.length < 3)
+            {
+                continue;
+            }
+
+            final UUID id = UUID.fromString(data[0]);
+            final String name = data[1];
+            final LocalDateTime localDateTime = LocalDateTime.parse(data[2], timeFormatter);
+
+            temp.put(id, new NameTime(name, localDateTime));
+        }
+
+        lastLoginTimes = temp;
+    }
+
+    @SubscribeEvent
+    public void onReload(ModConfigEvent.Reloading event)
+    {
+        reload();
+    }
+
+    @SubscribeEvent
+    public void onLoad(ModConfigEvent.Loading event)
+    {
+        reload();
+    }
+
+    @SubscribeEvent
+    public void onShutdown(ServerStoppingEvent event)
+    {
+        holder.save();
+    }
+
+    /**
+     * Resets the auth date
+     *
+     * @param profile
+     */
+    public void updateAuthFor(final @NotNull GameProfile profile)
+    {
+        lastLoginTimes.put(profile.getId(), new NameTime(profile.getName(), LocalDateTime.now()));
+
+        List<String> stringData = new ArrayList<>();
+
+        for (final Map.Entry<UUID, NameTime> entry : lastLoginTimes.entrySet())
+        {
+            stringData.add(entry.getKey().toString() + ";" + entry.getValue().name + ";" + timeFormatter.format(entry.getValue().time));
+        }
+
+        loginTimes.set(stringData);
+    }
+
+    /**
+     * Checks if the id has been authenticated recently
+     *
+     * @param id
+     * @return
+     */
+    public boolean hasOfflineAuth(final UUID id)
+    {
+        final NameTime nameTime = lastLoginTimes.get(id);
+        if (nameTime == null)
+        {
+            return false;
+        }
+
+        return Duration.between(LocalDateTime.now(), nameTime.time).abs().getSeconds() < offlineAuthValidHours.get() * 60L * 60L;
+    }
+
+    private static record NameTime(
+        String name,
+        LocalDateTime time) {}
+}

--- a/src/main/java/com/ldtteam/patreonwhitelist/PatreonWhitelist.java
+++ b/src/main/java/com/ldtteam/patreonwhitelist/PatreonWhitelist.java
@@ -5,9 +5,12 @@ package com.ldtteam.patreonwhitelist;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.javafmlmod.FMLModContainer;
+import net.neoforged.neoforge.common.ModConfigSpec;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
 
@@ -16,9 +19,20 @@ public class PatreonWhitelist
 {
     public static final String MOD_ID = "patreonwhitelist";
 
+    public static Commonconfig config;
+
     public PatreonWhitelist(final FMLModContainer modContainer, final Dist dist)
     {
         NeoForge.EVENT_BUS.register(this.getClass());
+
+        Pair<Commonconfig, ModConfigSpec> pair =
+            new ModConfigSpec.Builder().configure(Commonconfig::new);
+        modContainer.registerConfig(ModConfig.Type.COMMON, pair.getRight());
+        config = pair.getLeft();
+        config.holder = pair.getRight();
+        modContainer.getEventBus().addListener(config::onReload);
+        modContainer.getEventBus().addListener(config::onLoad);
+        NeoForge.EVENT_BUS.addListener(config::onShutdown);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/ldtteam/patreonwhitelist/WhitelistOverride.java
+++ b/src/main/java/com/ldtteam/patreonwhitelist/WhitelistOverride.java
@@ -22,9 +22,26 @@ public class WhitelistOverride extends UserWhiteList
     @Override
     public boolean isWhiteListed(@NotNull GameProfile profile)
     {
-        boolean isWhitelisted = super.isWhiteListed(profile);
-        Log.getLogger().log(Level.INFO, "Patreon Whitelist validating, File value: " + isWhitelisted);
-        return isWhitelisted || this.checkUrl("https://auth.minecolonies.com/api/minecraft/" + profile.getId().toString() + "/whitelist");
+        if (this.checkUrl("https://auth.minecolonies.com/api/minecraft/" + profile.getId().toString() + "/whitelist"))
+        {
+            PatreonWhitelist.config.updateAuthFor(profile);
+            Log.getLogger().log(Level.INFO, "Online authenticated");
+            return true;
+        }
+
+        if (super.isWhiteListed(profile))
+        {
+            Log.getLogger().log(Level.INFO, "Whitelist authenticated");
+            return true;
+        }
+
+        if (PatreonWhitelist.config.hasOfflineAuth(profile.getId()))
+        {
+            Log.getLogger().log(Level.INFO, "Offline authenticated");
+            return true;
+        }
+
+        return false;
     }
 
     private boolean checkUrl(String urlString)


### PR DESCRIPTION
Add config which caches the last login time and allows auth to work for a given time even after the service went down
Tested in smp